### PR TITLE
ipfshttpclientライブラリの削除とIpfsClientの追加

### DIFF
--- a/pkgs/cryptree/ipfs_client.py
+++ b/pkgs/cryptree/ipfs_client.py
@@ -1,0 +1,33 @@
+import requests
+from io import BytesIO
+
+class IpfsClient:
+    def __init__(self, ipfs_daemon_url='http://127.0.0.1:5001'):
+        self.ipfs_daemon_url = ipfs_daemon_url
+
+    def add_bytes(self, string_data: bytes):
+        url = f'{self.ipfs_daemon_url}/api/v0/add'
+        string_bytes = BytesIO(string_data)
+        files = {'file': ('string_data.txt', string_bytes)}
+        response = requests.post(url, files=files)
+        if response.ok:
+            ipfs_hash = response.json()['Hash']
+            print(f'String uploaded to IPFS with hash: {ipfs_hash}')
+            return ipfs_hash
+        else:
+            print('Error uploading string to IPFS')
+            print(response.text)
+            return None
+
+    def cat(self, ipfs_hash):
+        url = f'{self.ipfs_daemon_url}/api/v0/cat?arg={ipfs_hash}'
+        print(f'Fetching data from IPFS with hash: {ipfs_hash}')
+        print(f'URL: {url}')
+        response = requests.post(url, stream=True)
+        if response.status_code == 200:
+            data = response.content
+            return data
+        else:
+            print('Error getting data from IPFS')
+            print(response.text)
+            return None

--- a/pkgs/cryptree/main.py
+++ b/pkgs/cryptree/main.py
@@ -10,14 +10,14 @@ from model import GenerateRootNodeRequest, CreateNodeRequest, FetchNodeRequest, 
 import os
 from dotenv import load_dotenv
 from fake_ipfs import FakeIPFS
-import ipfshttpclient
+from ipfs_client import IpfsClient
 
 # .envファイルの内容を読み込見込む
 load_dotenv()
 
 # 例: 環境変数 'TEST_ENV' が 'True' の場合にのみ実際の接続を行う
 if os.environ.get('TEST_ENV') != 'True':
-    ipfs_client = ipfshttpclient.connect()
+    ipfs_client = IpfsClient()
 else:
     ipfs_client = FakeIPFS()  # テスト用の偽のIPFSクライアント
 

--- a/pkgs/cryptree/requirements.txt
+++ b/pkgs/cryptree/requirements.txt
@@ -3,7 +3,6 @@ botocore==1.34.65
 cryptography==42.0.5
 eth_account==0.10.0
 fastapi==0.110.0
-ipfshttpclient==0.7.0
 pydantic==2.6.4
 python-dotenv==1.0.1
 python_jose==3.3.0


### PR DESCRIPTION


```
ipfshttpclient.exceptions.VersionMismatch: Unsupported daemon version '0.26.0' (not in range: 0.4.23 ≤ … < 0.8.0)
```

- このエラーが出てipfs daemonとipfshttpclient合わせて使えないので後者を廃止
    - 直接httpリクエスト投げるクラス(IpfsClient)を作成し対応